### PR TITLE
fix offset bug

### DIFF
--- a/collections/clojure/lang/PersistentUnrolledMap.java
+++ b/collections/clojure/lang/PersistentUnrolledMap.java
@@ -811,7 +811,7 @@ public class PersistentUnrolledMap {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -1160,7 +1160,7 @@ public class PersistentUnrolledMap {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -1570,7 +1570,7 @@ public class PersistentUnrolledMap {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -2044,7 +2044,7 @@ public class PersistentUnrolledMap {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -2578,7 +2578,7 @@ public class PersistentUnrolledMap {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -3183,7 +3183,7 @@ public class PersistentUnrolledMap {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {

--- a/collections/clojure/lang/PersistentUnrolledVector.java
+++ b/collections/clojure/lang/PersistentUnrolledVector.java
@@ -329,7 +329,7 @@ public class PersistentUnrolledVector {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -570,7 +570,7 @@ public class PersistentUnrolledVector {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -816,7 +816,7 @@ public class PersistentUnrolledVector {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -1087,7 +1087,7 @@ public class PersistentUnrolledVector {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -1384,7 +1384,7 @@ public class PersistentUnrolledVector {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {
@@ -1709,7 +1709,7 @@ public class PersistentUnrolledVector {
 	    }
 
 	    public IChunk chunkedFirst() {
-		return new ArrayChunk(toArray(), offset);
+		return new ArrayChunk(toArray(), 0);
 	    }
 
 	    public ISeq chunkedNext() {

--- a/generate/cambrian_collections/map.clj
+++ b/generate/cambrian_collections/map.clj
@@ -462,7 +462,7 @@
             "this.meta = meta;")
 
           (j/method '[public] 'IChunk 'chunkedFirst []
-            "return new " (j/invoke 'ArrayChunk "toArray()" 'offset) ";")
+            "return new " (j/invoke 'ArrayChunk "toArray()" 0) ";")
 
           (j/method '[public] 'ISeq 'chunkedNext []
             "return null;")

--- a/generate/cambrian_collections/vector.clj
+++ b/generate/cambrian_collections/vector.clj
@@ -437,7 +437,7 @@
             "this.meta = meta;")
 
           (j/method '[public] 'IChunk 'chunkedFirst []
-            "return new " (j/invoke 'ArrayChunk "toArray()" 'offset) ";")
+            "return new " (j/invoke 'ArrayChunk "toArray()" 0) ";")
 
           (j/method '[public] 'ISeq 'chunkedNext []
             "return null;")


### PR DESCRIPTION
toArray is called on UnrolledChunkedSeq, not on the enclosing CardN
class. As a result, ArrayChunk gets an array with offset elements
chopped off _and_ an offset, so offset is doubly applied.

Passing 0 instead of offset to ArrayChunk solves the problem and
restores correct behavior.
